### PR TITLE
C:S 1.15.x compatibility fix

### DIFF
--- a/Content/DestinationDisplayManager.cs
+++ b/Content/DestinationDisplayManager.cs
@@ -5,7 +5,7 @@ namespace CSLShowCommuterDestination
 {
     public class DestinationDisplayManager : SimulationManagerBase<DestinationDisplayManager, MonoBehaviour>, IRenderableManager
     {
-        public Notification.Problem m_Notification = Notification.Problem.TooLong | Notification.Problem.MajorProblem;
+        public Notification.ProblemStruct m_Notification = new Notification.ProblemStruct(Notification.Problem1.TooLong | Notification.Problem1.MajorProblem);
 
         protected override void BeginOverlayImpl(RenderManager.CameraInfo cameraInfo)
         {


### PR DESCRIPTION
Resolves #5 

Small change because of vanilla changed how Problems are stored - all mods which used it will not load at all causing `ReflectionTypeLoadException` and also mentioned error from the Option screen builder
```cs
System.IndexOutOfRangeException: Array index is out of range.
at OptionsMainPanel.AddUserMods()).
```

_Note: I have no idea why git diff shows that whole file has changed even if I only changed one line and I also **did not** use any code formatting tools_ 🤷‍♂️ 