### PR TITLE
feat: make IPT2 integration completely optional, show presence on settings page

### DIFF
--- a/Content/StopDestinationInfoPanel.cs
+++ b/Content/StopDestinationInfoPanel.cs
@@ -1,10 +1,8 @@
-﻿using ColossalFramework;
-using ColossalFramework.UI;
+﻿using ColossalFramework.UI;
 using CSLShowCommuterDestination.Game;
+using CSLShowCommuterDestination.Game.Integrations;
 using CSLShowCommuterDestination.Graph;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using UnityEngine;
 

--- a/Content/StopDestinationInfoPanel.cs
+++ b/Content/StopDestinationInfoPanel.cs
@@ -47,6 +47,8 @@ namespace CSLShowCommuterDestination
             StopDestinationInfoPanel.instance = this;
             base.Start();
             this.SetupPanel();
+
+            ModIntegrations.CheckEnabledMods();
         }
 
         public override void Update()

--- a/Content/StopDestinationInfoPanel.cs
+++ b/Content/StopDestinationInfoPanel.cs
@@ -2,8 +2,6 @@
 using CSLShowCommuterDestination.Game;
 using CSLShowCommuterDestination.Game.Integrations;
 using CSLShowCommuterDestination.Graph;
-using System;
-using System.Reflection;
 using UnityEngine;
 
 namespace CSLShowCommuterDestination
@@ -58,17 +56,10 @@ namespace CSLShowCommuterDestination
 
         public void Show(ushort stopId)
         {
-            InstanceID instanceId = InstanceID.Empty;
-            instanceId.NetNode = stopId;
-
-            if (!InstanceManager.IsValid(instanceId))
+            if (ModIntegrations.IsIPT2Enabled())
             {
-                Debug.LogWarning("Invalid instance ID for StopDestinationInfoPanel");
-                this.Hide();
-                return;
+                IPT2Integration.ShowStopPanel(stopId);
             }
-
-            this.AttemptToShowIPT2Panel(instanceId);
 
             this.stopId = stopId;
             this.transportLineId = Bridge.GetStopTransportLineId(this.stopId);
@@ -98,50 +89,6 @@ namespace CSLShowCommuterDestination
             var nextStop = TransportLine.GetNextStop(this.stopId);
 
             this.Show(nextStop);
-        }
-
-        private void AttemptToShowIPT2Panel(InstanceID instanceId)
-        {
-            Type iptType = Type.GetType("ImprovedPublicTransport2.PublicTransportStopWorldInfoPanel, ImprovedPublicTransport2");
-
-            if (iptType == null)
-            {
-                Debug.LogWarning("IPT2 panel type not found");
-                return;
-            }
-
-            var instanceField = iptType.GetField("instance", BindingFlags.Public | BindingFlags.Static);
-
-            if (instanceField == null)
-            {
-                Debug.LogWarning("'instance' field found in PublicTransportStopWorldInfoPanel");
-                return;
-            }
-
-            var iptStopPanelInstance = instanceField.GetValue(null);
-
-            if (iptStopPanelInstance == null)
-            {
-                Debug.LogWarning("'instance' field was null");
-                return;
-            }
-
-            var showMethod = iptType.GetMethod(
-                "Show",
-                BindingFlags.Public | BindingFlags.Instance,
-                null,
-                new[] { typeof(Vector3), typeof(InstanceID) },
-                null
-            );
-
-            if (showMethod == null)
-            {
-                Debug.LogWarning("'Show' method not found in PublicTransportStopWorldInfoPanel");
-                return;
-            }
-
-            var arguments = new object[] { Bridge.GetStopPosition(instanceId.NetNode), instanceId };
-            showMethod.Invoke(iptStopPanelInstance, arguments);
         }
         
         private void CheckForClose()

--- a/Game/Integrations/IPT2Integration.cs
+++ b/Game/Integrations/IPT2Integration.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CSLShowCommuterDestination.Game.Integrations
+{
+    /**
+     * Integration with Improved Public Transport 2
+     * 
+     * https://steamcommunity.com/sharedfiles/filedetails/?id=928128676
+     */
+    public class IPT2Integration
+    {
+        public const string ASSEMBLY_NAME = "ImprovedPublicTransport2";
+    }
+}

--- a/Game/Integrations/IPT2Integration.cs
+++ b/Game/Integrations/IPT2Integration.cs
@@ -13,6 +13,9 @@ namespace CSLShowCommuterDestination.Game.Integrations
     {
         public const string ASSEMBLY_NAME = "ImprovedPublicTransport2";
 
+        /**
+         * Open the IPT2 stop panel for the given stop.
+         */
         public static void ShowStopPanel(ushort stopId)
         {
             if (!ModIntegrations.IsIPT2Enabled())

--- a/Game/Integrations/IPT2Integration.cs
+++ b/Game/Integrations/IPT2Integration.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Reflection;
+using UnityEngine;
 
 namespace CSLShowCommuterDestination.Game.Integrations
 {
@@ -13,5 +12,63 @@ namespace CSLShowCommuterDestination.Game.Integrations
     public class IPT2Integration
     {
         public const string ASSEMBLY_NAME = "ImprovedPublicTransport2";
+
+        public static void ShowStopPanel(ushort stopId)
+        {
+            if (!ModIntegrations.IsIPT2Enabled())
+            {
+                return;
+            }
+
+            InstanceID instanceId = InstanceID.Empty;
+            instanceId.NetNode = stopId;
+
+            if (!InstanceManager.IsValid(instanceId))
+            {
+                Debug.LogWarning("Invalid instance ID for IPT2Integration.ShowStopPanel");
+                return;
+            }
+
+            Type iptType = Type.GetType(ASSEMBLY_NAME + ".PublicTransportStopWorldInfoPanel, " + ASSEMBLY_NAME);
+
+            if (iptType == null)
+            {
+                Debug.LogWarning("IPT2 panel type not found");
+                return;
+            }
+
+            var instanceField = iptType.GetField("instance", BindingFlags.Public | BindingFlags.Static);
+
+            if (instanceField == null)
+            {
+                Debug.LogWarning("'instance' field found in PublicTransportStopWorldInfoPanel");
+                return;
+            }
+
+            var iptStopPanelInstance = instanceField.GetValue(null);
+
+            if (iptStopPanelInstance == null)
+            {
+                Debug.LogWarning("'instance' field was null");
+                return;
+            }
+
+            var showMethod = iptType.GetMethod(
+                "Show",
+                BindingFlags.Public | BindingFlags.Instance,
+                null,
+                new[] { typeof(Vector3), typeof(InstanceID) },
+                null
+            );
+
+            if (showMethod == null)
+            {
+                Debug.LogWarning("'Show' method not found in PublicTransportStopWorldInfoPanel");
+                return;
+            }
+            
+            var arguments = new object[] { Bridge.GetStopPosition(stopId), instanceId };
+            showMethod.Invoke(iptStopPanelInstance, arguments);
+        }
     }
 }

--- a/Game/Integrations/ModIntegrations.cs
+++ b/Game/Integrations/ModIntegrations.cs
@@ -12,6 +12,9 @@ namespace CSLShowCommuterDestination.Game.Integrations
     {
         private static bool isIPT2Enabled = false;
 
+        /**
+         * Iterate through the currently enabled mods and check for the integrations we support.
+         */
         public static void CheckEnabledMods()
         {
             var enabledMods = new HashSet<string>();
@@ -27,7 +30,7 @@ namespace CSLShowCommuterDestination.Game.Integrations
         }
 
         /**
-         * Check if Improved Public Transport 2 is currently enabled.
+         * Is Improved Public Transport 2 currently enabled?
          * 
          * https://steamcommunity.com/sharedfiles/filedetails/?id=928128676
          * 

--- a/Game/Integrations/ModIntegrations.cs
+++ b/Game/Integrations/ModIntegrations.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace CSLShowCommuterDestination.Game
+namespace CSLShowCommuterDestination.Game.Integrations
 {
     /**
      * This class handles integrations with 3rd party mods - mostly checking if they are installed.
@@ -11,7 +11,7 @@ namespace CSLShowCommuterDestination.Game
     public class ModIntegrations
     {
         private static bool isIPT2Enabled = false;
-        
+
         public static void CheckEnabledMods()
         {
             var enabledMods = new HashSet<string>();
@@ -23,7 +23,7 @@ namespace CSLShowCommuterDestination.Game
                 }
             }
 
-            isIPT2Enabled = enabledMods.Contains("improvedpublictransport2");
+            isIPT2Enabled = enabledMods.Contains(IPT2Integration.ASSEMBLY_NAME);
         }
 
         /**

--- a/Game/Integrations/ModIntegrations.cs
+++ b/Game/Integrations/ModIntegrations.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using UnityEngine;
 
 namespace CSLShowCommuterDestination.Game.Integrations
 {
@@ -22,11 +23,14 @@ namespace CSLShowCommuterDestination.Game.Integrations
             {
                 foreach (Assembly assembly in plugin.GetAssemblies())
                 {
-                    if (plugin.isEnabled) enabledMods.Add(assembly.GetName().Name.ToLower());
+                    if (plugin.isEnabled)
+                    {
+                        enabledMods.Add(assembly.GetName().Name.ToLower());
+                    }
                 }
             }
 
-            isIPT2Enabled = enabledMods.Contains(IPT2Integration.ASSEMBLY_NAME);
+            isIPT2Enabled = enabledMods.Contains(IPT2Integration.ASSEMBLY_NAME.ToLower());
         }
 
         /**

--- a/Game/ModIntegrations.cs
+++ b/Game/ModIntegrations.cs
@@ -1,0 +1,41 @@
+﻿using ColossalFramework.Plugins;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CSLShowCommuterDestination.Game
+{
+    /**
+     * This class handles integrations with 3rd party mods - mostly checking if they are installed.
+     */
+    public class ModIntegrations
+    {
+        private static bool isIPT2Enabled = false;
+        
+        public static void CheckEnabledMods()
+        {
+            var enabledMods = new HashSet<string>();
+            foreach (PluginManager.PluginInfo plugin in PluginManager.instance.GetPluginsInfo())
+            {
+                foreach (Assembly assembly in plugin.GetAssemblies())
+                {
+                    if (plugin.isEnabled) enabledMods.Add(assembly.GetName().Name.ToLower());
+                }
+            }
+
+            isIPT2Enabled = enabledMods.Contains("improvedpublictransport2");
+        }
+
+        /**
+         * Check if Improved Public Transport 2 is currently enabled.
+         * 
+         * https://steamcommunity.com/sharedfiles/filedetails/?id=928128676
+         * 
+         * @return true if IPT2 is enabled, false otherwise.
+         */
+        public static bool IsIPT2Enabled()
+        {
+            return isIPT2Enabled;
+        }
+    }
+}

--- a/Mod.cs
+++ b/Mod.cs
@@ -1,12 +1,13 @@
 ﻿using CitiesHarmony.API;
 using ColossalFramework.UI;
-using CSLShowCommuterDestination.Game;
+using CSLShowCommuterDestination.Game.Integrations;
 using ICities;
 using UnityEngine;
 
 // ReSharper disable InconsistentNaming
 
-namespace CSLShowCommuterDestination {
+namespace CSLShowCommuterDestination
+{
     public class Mod : LoadingExtensionBase, IUserMod
     {
         private GameObject stopDestinationInfoPanel;

--- a/Mod.cs
+++ b/Mod.cs
@@ -1,5 +1,6 @@
 ﻿using CitiesHarmony.API;
 using ColossalFramework.UI;
+using CSLShowCommuterDestination.Game;
 using ICities;
 using UnityEngine;
 
@@ -10,7 +11,10 @@ namespace CSLShowCommuterDestination {
     {
         private GameObject stopDestinationInfoPanel;
 
-        public string Name => "CSL Commuter Destination";
+        public const string Version = "0.4.0";
+
+        public string Name => "CSL Commuter Destination " + Version;
+        
         public string Description => "See the destination of all passengers waiting at a public transport stop.";
 
         public void OnEnabled() {
@@ -31,6 +35,22 @@ namespace CSLShowCommuterDestination {
                 this.stopDestinationInfoPanel.transform.parent = uiView.transform;
                 this.stopDestinationInfoPanel.AddComponent<StopDestinationInfoPanel>();
             }
+        }
+
+        public void OnSettingsUI(UIHelperBase helper)
+        {
+            ModIntegrations.CheckEnabledMods();
+
+            var group = helper.AddGroup(Name) as UIHelper;
+            var panel = group.self as UIPanel;
+            group.AddSpace(10);
+
+            group = helper.AddGroup("Integrations") as UIHelper;
+            panel = group.self as UIPanel;
+
+            var ipt2Label = panel.AddUIComponent<UILabel>();
+            ipt2Label.name = "integration_ipt2";
+            ipt2Label.text = "Improved Public Transport 2: " + (ModIntegrations.IsIPT2Enabled() ? "Detected" : "Not detected");
         }
     }
 }


### PR DESCRIPTION
Previously the mod would always attempt to open the IPT2 panel. Now it will only do so if we detect IPT2 as being enabled

Closes #4 