### PR TITLE
Use MSBuildProgramFiles32 for better dll search

### DIFF
--- a/CSLShowCommuterDestination.csproj
+++ b/CSLShowCommuterDestination.csproj
@@ -12,19 +12,19 @@
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="Assembly-CSharp">
-		  <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
+		  <HintPath>$(MSBuildProgramFiles32)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
 		  <Private>False</Private>
 		</Reference>
 		<Reference Include="ColossalManaged">
-		  <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
+		  <HintPath>$(MSBuildProgramFiles32)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
 		  <Private>False</Private>
 		</Reference>
 		<Reference Include="ICities">
-		  <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
+		  <HintPath>$(MSBuildProgramFiles32)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
 		  <Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine">
-		  <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
+		  <HintPath>$(MSBuildProgramFiles32)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
 		  <Private>False</Private>
 		</Reference>
 	</ItemGroup>


### PR DESCRIPTION
Using MSBuildProgramFiles32 in order to find the referenced dll files is a safer, path indenpendent way which works on all machines